### PR TITLE
[Fix] 관리자의 사용자 목록 전체 조회 로직 변경

### DIFF
--- a/src/main/java/com/example/shoppingmallserver/controller/UserController.java
+++ b/src/main/java/com/example/shoppingmallserver/controller/UserController.java
@@ -5,7 +5,7 @@ import com.example.shoppingmallserver.base.SuccessResponse;
 import com.example.shoppingmallserver.dto.*;
 import com.example.shoppingmallserver.entity.user.User;
 import com.example.shoppingmallserver.entity.user.UserDetail;
-import com.example.shoppingmallserver.service.Keyword;
+import com.example.shoppingmallserver.service.Category;
 import com.example.shoppingmallserver.service.UserService;
 
 import com.example.shoppingmallserver.utils.JwtTokenProvider;
@@ -257,21 +257,15 @@ public class UserController {
     /**
      * 관리자가 키워드를 기반으로 사용자 정보 목록을 조회합니다.
      *
-     * @param keyword 사용자 정보에서 검색할 키워드
+     * @param category 사용자 정보에서 검색할 키워드
      * @return 성공 응답 메시지와 함께 조회한 사용자 정보 목록을 담은 DTO 목록을 반환
      */
     @GetMapping("/admin/find")
     @Operation(summary = "(관리자) 사용자 정보 목록 조회", description = "관리자가 사용자 정보 목록을 조회합니다.")
-    public ResponseEntity<SuccessResponse<List<AdminReadUserListDto>>> adminGetUserList(@RequestParam(value = "keyword", required = false) @Parameter(description = "(관리자) 사용자 검색 키워드", example = "김디팡") Keyword keyword, Pageable pageable) {
+    public ResponseEntity<SuccessResponse<List<AdminReadUserListDto>>> adminGetUserList(@RequestParam(value = "category", required = false) @Parameter(description = "(관리자) 사용자 검색 키워드", example = "김디팡") Category category, String keyword, Pageable pageable) {
 
         // 키워드를 기반으로 사용자 정보 목록을 조회 (관리자용)
-        List<AdminReadUserListDto> userDetails = userService.getUserList(keyword, pageable);
-
-//        // 조회한 사용자 정보 목록을 이용하여 응답 DTO 목록을 생성 (관리자용)
-//        List<AdminReadUserListDto> data = userDetails
-//                .stream()
-//                .map(AdminReadUserListDto::new)
-//                .toList();
+        List<AdminReadUserListDto> userDetails = userService.getUserList(category, keyword, pageable);
 
         // 생성한 응답 DTO 목록을 포함하는 성공 응답 메시지를 생성하고, 이를 ResponseEntity로 감싸어 반환
         // 이를 통해 API 호출한 클라이언트에게 사용자 정보 목록이 성공적으로 조회되었음을 알림

--- a/src/main/java/com/example/shoppingmallserver/repository/UserDetailRepository.java
+++ b/src/main/java/com/example/shoppingmallserver/repository/UserDetailRepository.java
@@ -14,6 +14,10 @@ import java.util.List;
  */
 public interface UserDetailRepository extends JpaRepository<UserDetail, Long> {
 
+    Page<UserDetail> findByEmployeeNumberContaining(String keyword, Pageable pageable);
+
+    Page<UserDetail> findByEmailContaining(String keyword, Pageable pageable);
+
     /**
      * 사용자 이름에 특정 키워드가 포함된 사용자의 상세 정보 목록을 조회합니다.
      * 이 메서드는 주로 관리자가 사용자 정보를 검색할 때 사용됩니다.
@@ -23,6 +27,8 @@ public interface UserDetailRepository extends JpaRepository<UserDetail, Long> {
      * @return 키워드가 포함된 사용자 이름을 가진 사용자의 상세 정보 목록
      */
     Page<UserDetail> findByNameContaining(String keyword, Pageable pageable);
+
+    Page<UserDetail> findByJoinDateContaining(String keyword, Pageable pageable);
 
 
     UserDetail findByUserId(Long userId);

--- a/src/main/java/com/example/shoppingmallserver/service/Category.java
+++ b/src/main/java/com/example/shoppingmallserver/service/Category.java
@@ -1,6 +1,6 @@
 package com.example.shoppingmallserver.service;
 
-public enum Keyword {
+public enum Category {
     EMPLOYEENUMBER,
     EMAIL,
     NAME,

--- a/src/main/java/com/example/shoppingmallserver/service/UserService.java
+++ b/src/main/java/com/example/shoppingmallserver/service/UserService.java
@@ -73,7 +73,7 @@ public interface UserService {
     UserDetail getAdminUserById(Long userId);
 
     // 관리자의 사용자 정보 리스트 조회
-    List<AdminReadUserListDto> getUserList(Keyword keyword, Pageable pageable);
+    List<AdminReadUserListDto> getUserList(Category category, String keyword, Pageable pageable);
 
     // 관리자의 사용자 정보 삭제
     void deleteUser(List<Long> userIds);

--- a/src/main/java/com/example/shoppingmallserver/service/UserServiceImpl.java
+++ b/src/main/java/com/example/shoppingmallserver/service/UserServiceImpl.java
@@ -304,14 +304,39 @@ public class UserServiceImpl implements UserService {
 
     // 관리자의 사용자 정보 리스트 조회
     @Override
-    public List<AdminReadUserListDto> getUserList(Keyword keyword, Pageable pageable) {
+    public List<AdminReadUserListDto> getUserList(Category category, String keyword, Pageable pageable) {
 
-        if (keyword != null) {
-            Page<UserDetail> userIds = userDetailRepository.findByNameContaining(keyword.name(), pageable);
-            log.info("조건에 따른 사용자 정보 조회 성공. 조건: {}", keyword);
-            return userIds.stream()
-                    .map(AdminReadUserListDto::new)
-                    .collect(Collectors.toList());
+        if (category != null) {
+            switch (category) {
+                case EMPLOYEENUMBER -> {
+                    Page<UserDetail> userIds = userDetailRepository.findByEmployeeNumberContaining(keyword, pageable);
+                    log.info("조건에 따른 사용자 정보 조회 성공. 조건: {}", keyword);
+                    return userIds.stream()
+                            .map(AdminReadUserListDto::new)
+                            .collect(Collectors.toList());
+                }
+                case EMAIL -> {
+                    Page<UserDetail> userIds = userDetailRepository.findByEmailContaining(keyword, pageable);
+                    log.info("조건에 따른 사용자 정보 조회 성공. 조건: {}", keyword);
+                    return userIds.stream()
+                            .map(AdminReadUserListDto::new)
+                            .collect(Collectors.toList());
+                }
+                case NAME -> {
+                    Page<UserDetail> userIds = userDetailRepository.findByNameContaining(keyword, pageable);
+                    log.info("조건에 따른 사용자 정보 조회 성공. 조건: {}", keyword);
+                    return userIds.stream()
+                            .map(AdminReadUserListDto::new)
+                            .collect(Collectors.toList());
+                }
+                case JOINDATE -> {
+                    Page<UserDetail> userIds = userDetailRepository.findByJoinDateContaining(keyword, pageable);
+                    log.info("조건에 따른 사용자 정보 조회 성공. 조건: {}", keyword);
+                    return userIds.stream()
+                            .map(AdminReadUserListDto::new)
+                            .collect(Collectors.toList());
+                }
+            }
         } else {
             Page<UserDetail> userIds = userDetailRepository.findAll(pageable);
             log.info("사용자 전체 정보 조회 성공.");
@@ -319,6 +344,8 @@ public class UserServiceImpl implements UserService {
                     .map(AdminReadUserListDto::new)
                     .collect(Collectors.toList());
         }
+        log.info("조건을 잘못 입력하였습니다. 사실 이 로그는 시스템적으로 볼 수 없습니다. 만약 이 로그를 보게 된다면 당장 파드를 종료하고 새로운 버전으로 릴리즈 하십시오.");
+        return null;
     }
 
     // 관리자의 사용자 정보 삭제


### PR DESCRIPTION
이제 카테고리를 정할 수 있고 카테고리에 따라 검색을 시도할 수 있으며, 카테고리를 정하지 않으면 전체 사용자를 조회합니다.