### PR TITLE
[Fix] 관리자의 사용자 목록 조회 API 로직 수정 및 입사일 카테고리 제거

### DIFF
--- a/src/main/java/com/example/shoppingmallserver/controller/UserController.java
+++ b/src/main/java/com/example/shoppingmallserver/controller/UserController.java
@@ -262,7 +262,7 @@ public class UserController {
      */
     @GetMapping("/admin/find")
     @Operation(summary = "(관리자) 사용자 정보 목록 조회", description = "관리자가 사용자 정보 목록을 조회합니다.")
-    public ResponseEntity<SuccessResponse<List<AdminReadUserListDto>>> adminGetUserList(@RequestParam(value = "category", required = false) @Parameter(description = "(관리자) 사용자 검색 키워드", example = "김디팡") Category category, String keyword, Pageable pageable) {
+    public ResponseEntity<SuccessResponse<List<AdminReadUserListDto>>> adminGetUserList(@RequestParam @Parameter(description = "(관리자) 사용자 검색 카테고리", example = "NULL") Category category, @RequestParam(required = false) @Parameter(description = "(관리자) 사용자 검색 키워드", example = "김디팡") String keyword, Pageable pageable) {
 
         // 키워드를 기반으로 사용자 정보 목록을 조회 (관리자용)
         List<AdminReadUserListDto> userDetails = userService.getUserList(category, keyword, pageable);
@@ -273,7 +273,6 @@ public class UserController {
                 new SuccessResponse<>(HttpStatus.OK.value(), "사용자 정보를 성공적으로 조회하였습니다.", userDetails),
                 HttpStatus.OK
         );
-
     }
 
     /**

--- a/src/main/java/com/example/shoppingmallserver/entity/user/User.java
+++ b/src/main/java/com/example/shoppingmallserver/entity/user/User.java
@@ -7,10 +7,7 @@ import com.example.shoppingmallserver.entity.wishlist.Wishlist;
 
 import jakarta.persistence.*;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import static jakarta.persistence.CascadeType.*;
 
@@ -20,6 +17,7 @@ import static jakarta.persistence.CascadeType.*;
  * 사용자 상세, 장바구니 항목, 위시리스트 항목, 마일리지와의 관계를 정의합니다.
  */
 @Getter
+@Setter(value = AccessLevel.PACKAGE)
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/example/shoppingmallserver/repository/UserDetailRepository.java
+++ b/src/main/java/com/example/shoppingmallserver/repository/UserDetailRepository.java
@@ -20,11 +20,11 @@ public interface UserDetailRepository extends JpaRepository<UserDetail, Long> {
     /**
      * 사용자의 사원 번호에 특정 키워드가 포함된 사용자의 상세 정보 목록을 페이지네이션하여 조회합니다.
      *
-     * @param keyword  사원 번호에서 검색할 키워드
+     * @param employeeNumber  사원 번호에서 검색할 키워드
      * @param pageable 페이지네이션 정보
      * @return 키워드가 포함된 사원 번호를 가진 사용자의 상세 정보 목록
      */
-    Page<UserDetail> findByEmployeeNumberContaining(String keyword, Pageable pageable);
+    Page<UserDetail> findByEmployeeNumber(Long employeeNumber, Pageable pageable);
 
     /**
      * 사용자의 이름에 특정 키워드가 포함된 사용자의 상세 정보 목록을 페이지네이션하여 조회합니다.
@@ -34,15 +34,6 @@ public interface UserDetailRepository extends JpaRepository<UserDetail, Long> {
      * @return 키워드가 포함된 사용자 이름을 가진 사용자의 상세 정보 목록
      */
     Page<UserDetail> findByNameContaining(String keyword, Pageable pageable);
-
-    /**
-     * 사용자의 가입 날짜에 특정 키워드가 포함된 사용자의 상세 정보 목록을 페이지네이션하여 조회합니다.
-     *
-     * @param keyword  가입 날짜에서 검색할 키워드
-     * @param pageable 페이지네이션 정보
-     * @return 키워드가 포함된 가입 날짜를 가진 사용자의 상세 정보 목록
-     */
-    Page<UserDetail> findByJoinDateContaining(String keyword, Pageable pageable);
 
     /**
      * 사용자 ID에 해당하는 사용자의 상세 정보를 조회합니다.

--- a/src/main/java/com/example/shoppingmallserver/repository/UserRepository.java
+++ b/src/main/java/com/example/shoppingmallserver/repository/UserRepository.java
@@ -21,7 +21,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
      */
     Optional<User> findByEmail(String email);
 
-    Page<UserDetail> findByEmailContaining(String keyword, Pageable pageable);
+    Page<User> findByEmailContaining(String keyword, Pageable pageable);
 
     /**
      * 사용자 ID에 해당하는 사용자와 그에 연관된 사용자의 상세 정보를 함께 조회합니다.

--- a/src/main/java/com/example/shoppingmallserver/service/Category.java
+++ b/src/main/java/com/example/shoppingmallserver/service/Category.java
@@ -3,6 +3,5 @@ package com.example.shoppingmallserver.service;
 public enum Category {
     EMPLOYEENUMBER,
     EMAIL,
-    NAME,
-    JOINDATE
+    NAME
 }

--- a/src/main/java/com/example/shoppingmallserver/service/UserServiceImpl.java
+++ b/src/main/java/com/example/shoppingmallserver/service/UserServiceImpl.java
@@ -306,46 +306,49 @@ public class UserServiceImpl implements UserService {
     @Override
     public List<AdminReadUserListDto> getUserList(Category category, String keyword, Pageable pageable) {
 
-        if (category != null) {
+        // 키워드가 있는 경우
+        if(keyword != null) {
             switch (category) {
                 case EMPLOYEENUMBER -> {
-                    Page<UserDetail> userIds = userDetailRepository.findByEmployeeNumberContaining(keyword, pageable);
-                    log.info("조건에 따른 사용자 정보 조회 성공. 조건: {}", keyword);
+                    Long employeeNumber = Long.parseLong(keyword);
+                    Page<UserDetail> userIds = userDetailRepository.findByEmployeeNumber(employeeNumber, pageable);
+                    log.info("키워드 조건에 따른 사용자 정보 조회 성공. 조건: {}. 키워드: {}.", category, keyword);
                     return userIds.stream()
                             .map(AdminReadUserListDto::new)
                             .collect(Collectors.toList());
                 }
                 case EMAIL -> {
-                    Page<UserDetail> userIds = userRepository.findByEmailContaining(keyword, pageable);
+                    Page<User> userIds = userRepository.findByEmailContaining(keyword, pageable);
                     log.info("조건에 따른 사용자 정보 조회 성공. 조건: {}", keyword);
                     return userIds.stream()
-                            .map(AdminReadUserListDto::new)
+                            .map(this::convertToDto)
                             .collect(Collectors.toList());
                 }
                 case NAME -> {
                     Page<UserDetail> userIds = userDetailRepository.findByNameContaining(keyword, pageable);
-                    log.info("조건에 따른 사용자 정보 조회 성공. 조건: {}", keyword);
-                    return userIds.stream()
-                            .map(AdminReadUserListDto::new)
-                            .collect(Collectors.toList());
-                }
-                case JOINDATE -> {
-                    Page<UserDetail> userIds = userDetailRepository.findByJoinDateContaining(keyword, pageable);
-                    log.info("조건에 따른 사용자 정보 조회 성공. 조건: {}", keyword);
+                    log.info("키워드 조건에 따른 사용자 정보 조회 성공. 조건: {}. 키워드: {}.", category, keyword);
                     return userIds.stream()
                             .map(AdminReadUserListDto::new)
                             .collect(Collectors.toList());
                 }
             }
-        } else {
+        }
+        else {
             Page<UserDetail> userIds = userDetailRepository.findAll(pageable);
             log.info("사용자 전체 정보 조회 성공.");
             return userIds.stream()
                     .map(AdminReadUserListDto::new)
                     .collect(Collectors.toList());
         }
-        log.info("조건을 잘못 입력하였습니다. 사실 이 로그는 시스템적으로 볼 수 없습니다. 만약 이 로그를 보게 된다면 당장 파드를 종료하고 새로운 버전으로 릴리즈 하십시오.");
-        return null;
+        Page<UserDetail> userIds = userDetailRepository.findAll(pageable);
+        log.info("사용자 전체 정보 조회 성공.");
+        return userIds.stream()
+                .map(AdminReadUserListDto::new)
+                .collect(Collectors.toList());
+    }
+
+    private AdminReadUserListDto convertToDto(User user) {
+        return new AdminReadUserListDto(user.getUserDetail());
     }
 
     // 관리자의 사용자 정보 삭제


### PR DESCRIPTION
사원번호에서 Long이어서 오류 생기는거 해결, Email이 UserDetail에 없어서 User로 조회하도록 수정, 입사일로 검색하는것 삭제