### PR TITLE
병합 충돌 수정 (#60)

### DIFF
--- a/src/main/java/com/example/shoppingmallserver/repository/UserRepository.java
+++ b/src/main/java/com/example/shoppingmallserver/repository/UserRepository.java
@@ -21,7 +21,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
      */
     Optional<User> findByEmail(String email);
 
-  
     Page<User> findByEmailContaining(String keyword, Pageable pageable);
 
     /**

--- a/src/main/java/com/example/shoppingmallserver/service/Category.java
+++ b/src/main/java/com/example/shoppingmallserver/service/Category.java
@@ -3,5 +3,6 @@ package com.example.shoppingmallserver.service;
 public enum Category {
     EMPLOYEENUMBER,
     EMAIL,
-    NAME
+    NAME,
+    ALL
 }

--- a/src/main/java/com/example/shoppingmallserver/service/UserServiceImpl.java
+++ b/src/main/java/com/example/shoppingmallserver/service/UserServiceImpl.java
@@ -336,6 +336,13 @@ public class UserServiceImpl implements UserService {
                             .map(AdminReadUserListDto::new)
                             .collect(Collectors.toList());
                 }
+                case ALL -> {
+                    Page<UserDetail> userIds = userDetailRepository.findAll(pageable);
+                    log.info("사용자 전체 정보 조회 성공.");
+                    return userIds.stream()
+                            .map(AdminReadUserListDto::new)
+                            .collect(Collectors.toList());
+                }
             }
         }
         else {


### PR DESCRIPTION
* [Fix] 관리자의 사용자 목록 조회 API 로직 수정 및 입사일 카테고리 제거

사원번호에서 Long이어서 오류 생기는거 해결, Email이 UserDetail에 없어서 User로 조회하도록 수정, 입사일로 검색하는것 삭제

* [Hotfix] 관리자의 사용자 목록 조회 API 수정

전체 카테고리 추가(ALL)