### PR TITLE
[Fix] LoginRequestDto 오류 해결

### DIFF
--- a/src/main/java/com/example/shoppingmallserver/dto/LoginRequestDto.java
+++ b/src/main/java/com/example/shoppingmallserver/dto/LoginRequestDto.java
@@ -4,15 +4,17 @@ import com.example.shoppingmallserver.entity.user.User;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Schema(description = "로그인 정보")
 @Getter
+@NoArgsConstructor
 public class LoginRequestDto {
 
     @Schema(description = "이메일", example = "qwer1234@naver.com")
-    private final String email;
+    private String email;
     @Schema(description = "비밀번호", example = "qwer1234!@#$")
-    private final String password;
+    private String password;
 
     public LoginRequestDto(User user) {
         this.email = user.getEmail();


### PR DESCRIPTION
InvalidDefinitionException -> 이 에러 메시지는 LoginRequestDto 클래스에 기본 생성자가 없어서 발생하는 문제입니다. Jackson 라이브러리는 JSON 문자열을 객체로 변환(역직렬화)할 때 기본 생성자를 사용합니다. 따라서 LoginRequestDto 클래스에 기본 생성자를 추가해야 합니다.