### PR TITLE
Update application.yml

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  main:
+    allow-bean-definition-overriding: true
   config:
     import: classpath:secret.yml
 


### PR DESCRIPTION
  main:
    allow-bean-definition-overriding: true 추가

'FeignClientSpecification' 빈의 등록에 실패했다는 메시지는 이미 같은 이름의 빈이 정의되어 있고, 오버라이딩이 비활성화되어 있기 때문에 발생하는 문제입니다. 이 문제를 해결하기 위해 다음과 같은 방법들을 시도해볼 수 있습니다.

오버라이딩 활성화: Spring Boot에서는 빈 오버라이딩이 기본적으로 비활성화되어 있습니다. 따라서, 이미 존재하는 빈을 덮어쓰려면 오버라이딩을 활성화해야 합니다. application.properties 또는 application.yml 파일에 spring.main.allow-bean-definition-overriding=true를 추가하면 빈 오버라이딩을 활성화할 수 있습니다.